### PR TITLE
Fixed testing for correct libsdl in Ubuntu 14.04 

### DIFF
--- a/launcher-script.in
+++ b/launcher-script.in
@@ -87,7 +87,7 @@ testlibsdl () {
 	fi
 	
 	if [ "$LIBSDL" = "" -a -f "$1" ]; then
-		if [ "`file -b "$1" | grep "ELF 32-bit LSB shared object"`" != "" ]; then
+		if [ "`file -b "$1" | grep "ELF 32-bit LSB[[:space:]]*shared object"`" != "" ]; then
 			info "32-bit libSDL.so is installed to $1"
 			LIBSDL="$1"
 		fi


### PR DESCRIPTION
Due to changed output of file command. The output of the `file -b` command now outputs one space more (before shared) which brakes the script.

    [et-sdl-sound] info   : /usr/lib/i386-linux-gnu/libSDL-1.2.so.0.11.4
    [et-sdl-sound] info   :    ELF 32-bit LSB  shared object, Intel 80386, version 1 (SYSV), dynamically linked, BuildID[sha1]=4ce94cf7bbafb44af187aa3233ec1f30468f6fad, stripped.

The fix should be backward compatible to other `file -b` outputs.

